### PR TITLE
Get demo building/linking on macos

### DIFF
--- a/nappgui-sys/build.rs
+++ b/nappgui-sys/build.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
 use std::process::Command;
+use std::env;
 
 fn main() {
     let out = build();
@@ -31,7 +32,7 @@ fn build() -> PathBuf {
         dst.define("CMAKE_OSX_SYSROOT", &sysroot);
     }
 
-    dst.profile("Release");
+    dst.profile(&env::var("PROFILE").unwrap());
     dst.build()
 }
 


### PR DESCRIPTION
Just a small fix to get the demo working on macos. (I just noticed part of this can be picked up by merging in a cmake fix from upstream so you might prefer that, who knows; I think the link-lib lines are still required).

I also added a thing to help debug native bits by passing PROFILE through build.rs.

Nice work btw, thanks!